### PR TITLE
Bug fix: Fix blanks screen

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -12,7 +12,6 @@ export default function Index() {
 
     // Standby screen
     const [isStandby, setIsStandby] = useState(true);
-    const [fadeOut, setFadeOut] = useState(false);
     const [lastActivity, setLastActivity] = useState(Date.now());
     const [standbyTime] = useState(MAX_IDLE_TIME);
     const resetInactivity = useCallback(() => {
@@ -48,7 +47,7 @@ export default function Index() {
     }, [resetInactivity]);
 
     const handleStart = () => {
-        setFadeOut(true);
+        // setFadeOut(true);
         setTimeout(() => {
             setIsStandby(false);
             resetInactivity();
@@ -80,11 +79,7 @@ export default function Index() {
                     <source src={assetId} type="video/mp4" />
                 </video>
 
-                {isStandby ? (
-                    <Standby onStart={handleStart} fadeOut={fadeOut} />
-                ) : (
-                    <ScreensWrapper />
-                )}
+                {isStandby ? <Standby onStart={handleStart} /> : <ScreensWrapper />}
             </View>
         </>
     );

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -46,14 +46,6 @@ export default function Index() {
         };
     }, [resetInactivity]);
 
-    const handleStart = () => {
-        // setFadeOut(true);
-        setTimeout(() => {
-            setIsStandby(false);
-            resetInactivity();
-        }, 500);
-    };
-
     return (
         <>
             <Head>
@@ -79,7 +71,7 @@ export default function Index() {
                     <source src={assetId} type="video/mp4" />
                 </video>
 
-                {isStandby ? <Standby onStart={handleStart} /> : <ScreensWrapper />}
+                {isStandby ? <Standby /> : <ScreensWrapper />}
             </View>
         </>
     );

--- a/components/Standby.tsx
+++ b/components/Standby.tsx
@@ -22,7 +22,7 @@ const CurrentTime = () => {
     );
 };
 
-export default function Standby({ onStart, fadeOut }: { onStart: () => void; fadeOut: boolean }) {
+export default function Standby({ onStart }: { onStart: () => void }) {
     const pulseAnim = useRef(new Animated.Value(1)).current;
 
     React.useEffect(() => {
@@ -54,8 +54,7 @@ export default function Standby({ onStart, fadeOut }: { onStart: () => void; fad
                 alignItems: 'center',
                 justifyContent: 'center',
                 backgroundColor: 'rgba(0, 0, 0, 0.6)',
-                opacity: fadeOut ? 0 : 1,
-                pointerEvents: fadeOut ? 'none' : 'auto',
+                pointerEvents: 'auto',
             }}
             onTouchStart={onStart} // <--- works cross-platform
         >

--- a/components/Standby.tsx
+++ b/components/Standby.tsx
@@ -22,7 +22,7 @@ const CurrentTime = () => {
     );
 };
 
-export default function Standby({ onStart }: { onStart: () => void }) {
+export default function Standby() {
     const pulseAnim = useRef(new Animated.Value(1)).current;
 
     React.useEffect(() => {
@@ -55,9 +55,7 @@ export default function Standby({ onStart }: { onStart: () => void }) {
                 justifyContent: 'center',
                 backgroundColor: 'rgba(0, 0, 0, 0.6)',
                 pointerEvents: 'auto',
-            }}
-            onTouchStart={onStart} // <--- works cross-platform
-        >
+            }}>
             <Image source={BCLogo} style={{ width: 700, height: 700, marginBottom: 20 }} />
 
             <Text style={{ fontSize: 60, color: 'white' }}>What do you know about your water?</Text>
@@ -86,8 +84,6 @@ export default function Standby({ onStart }: { onStart: () => void }) {
 
   - isStandby: (true/false) — shows standby screen or main content
 
-  - fadeOut: (true/false) — controls fading animation
-
   - lastActivity: (timestamp) — tracks last user interaction
 
   - standbyTime: (ms) — how long until it goes to standby
@@ -95,7 +91,5 @@ export default function Standby({ onStart }: { onStart: () => void }) {
   - resetInactivity(): when user touches/clicks/presses anything, reset the timer
 
   - checkInactivity: every second, check if user is inactive
-
-  - handleStart(): when tapping "Start", fades out standby screen and enters main app
 
 */


### PR DESCRIPTION
# What was changed
- Remove code causing the bug

## Cause:
In most caes this line is what causes the standy by screen to turn off:
https://github.com/bluecolab/react-kiosk/blob/31b94b6c20d4770246f4f4924b9d6ad0b6f11f90/app/index.tsx#L21

That function is called by if one of these events are triggred:
https://github.com/bluecolab/react-kiosk/blob/31b94b6c20d4770246f4f4924b9d6ad0b6f11f90/app/index.tsx#L37

We also have code here:
https://github.com/bluecolab/react-kiosk/blob/31b94b6c20d4770246f4f4924b9d6ad0b6f11f90/app/index.tsx#L50-L56

Those lines should also be closing the screen. That line is triggred when the stand by screen is touched. But in 99% cases those lines don't get triggred because the events themselves close it. Lines 50-56 never get to run.

BUT in rare instances that the events fail (or is delayed), touching the standy by screen is what actually closes the screen. In that instance it behaves the same except this line:
https://github.com/bluecolab/react-kiosk/blob/31b94b6c20d4770246f4f4924b9d6ad0b6f11f90/app/index.tsx#L51

`fadeout` is set to true. That is the problem, it is set true but no where do we set it back to false. 

Solution is to remove code since the events handle it. 